### PR TITLE
Bump bundler from 2.4.19 to 2.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.4.19
+   2.6.3


### PR DESCRIPTION
`bundle update --bundler`

This will allow us to add checksums to `Gemfile.lock`.