### PR TITLE
Bump Ruby in CI from 3.1.2 to 3.4.1 to fix failing spec

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis@7.2.7
+        image: redis:7.2.7
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis
+        image: redis@7.2.7
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        ruby-version: '3.1.2'
+        ruby-version: '3.4.1'
     - name: Run RSpec tests
       run: bin/rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:7.2.7
+        image: redis:7.4.2
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:7.4.2
+        image: redis
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"


### PR DESCRIPTION
I have no idea why, but without this change, there is a spec failure (caused by `Redis::TimeoutError` / `RedisClient::ReadTimeoutError` in `spec/backends/redis_spec.rb:61 # Pallets::Backends::Redis#pick with no work available does not add anything to the reliability set`), as seen here: https://github.com/davidrunger/pallets/actions/runs/12924838239/job/36044597257 .